### PR TITLE
Rename MemoryResult fields

### DIFF
--- a/app/src/main/java/io/groovin/mcpsample/mcp/localserver/memory/GetAllMemoryTool.kt
+++ b/app/src/main/java/io/groovin/mcpsample/mcp/localserver/memory/GetAllMemoryTool.kt
@@ -33,7 +33,7 @@ class GetAllMemoryTool(
         val memoryList = dbDao.getAllMemory()
 
         return if (memoryList.isNotEmpty()) {
-            val result = MemoryResult(notificationList = memoryList)
+            val result = MemoryResult(memoryList = memoryList)
             CallToolResult(
                 content = listOf(TextContent(Json.encodeToString(result)))
             )
@@ -48,7 +48,7 @@ class GetAllMemoryTool(
 
     @Serializable
     data class MemoryResult(
-        val notificationList: List<UserMemory>
+        val memoryList: List<UserMemory>
     )
 }
 

--- a/app/src/main/java/io/groovin/mcpsample/mcp/localserver/memory/SearchMemoryTool.kt
+++ b/app/src/main/java/io/groovin/mcpsample/mcp/localserver/memory/SearchMemoryTool.kt
@@ -54,7 +54,7 @@ class SearchMemoryTool(
         val memoryList = dbDao.searchMemory(keyword)
 
         return if (memoryList.isNotEmpty()) {
-            val result = MemoryResult(notificationList = memoryList)
+            val result = MemoryResult(memoryList = memoryList)
             CallToolResult(
                 content = listOf(TextContent(Json.encodeToString(result)))
             )
@@ -69,7 +69,7 @@ class SearchMemoryTool(
 
     @Serializable
     data class MemoryResult(
-        val notificationList: List<UserMemory>
+        val memoryList: List<UserMemory>
     )
 }
 


### PR DESCRIPTION
## Summary
- rename `notificationList` field to `memoryList` in memory tools

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843b920565483308388ed28c7b131aa